### PR TITLE
Add tests and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,35 @@
-# SOX - socket options extractor/setter.
----
-##### Sox enables you to retrieve or modify any TCP socket option for any process. This can be particularly useful for debugging purposes. Additionally, Sox can serve as a quick fix by allowing you to change socket options for any application without requiring a restart or causing downtime.
----
+# Sox
 
+Sox (Socket Options eXplorer) is a small command line tool that allows you to
+inspect and modify TCP socket options of any running process. It can be helpful
+for debugging or tuning network applications without restarting them.
 
-## Requirements:
-- Linux kernel 5.6+
-- `CAP_SYS_PTRACE` capability
+## Requirements
+- Linux kernel 5.6 or newer (for the pidfd API)
+- `CAP_SYS_PTRACE` capability to operate on foreign processes
 
-## Instalation:
-```
+## Installation
+```bash
 go install github.com/valexz/sox@latest
 ```
 
-## Usage example
+## Getting started
+1. Locate the target socket using `ss` or a similar tool to obtain the PID and
+   file descriptor.
 
+2. List all supported options for that socket:
+   ```bash
+   sudo sox list <pid> <fd>
+   ```
 
-### Get pid and fd of socket via ss:
-```
-❯ sudo ss -ntpa
-State       Recv-Q       Send-Q     Local Address:Port           Peer Address:Port        Process                                               
-LISTEN      0            128        0.0.0.0:22                   0.0.0.0:*                users:(("sshd",pid=1062,fd=3))                       
-```
+3. Get the value of a single option:
+   ```bash
+   sudo sox get <pid> <fd> TCP_NODELAY
+   ```
 
-### List all socket options for sshd process with PID=1062 and  tcp socket with FD=3
-```
-❯ sudo ./sox list 1062 3
-OPTION NAME             VALUE           DESCRIPTION                            
-SO_KEEPALIVE            1               Enable or disable TCP keepalive        
-TCP_KEEPIDLE            7200            Start keepalives after this period     
-TCP_KEEPINTVL           75              Interval between keepalives            
-TCP_KEEPCNT             9               Number of keepalives before death      
-TCP_NODELAY             0               Disable Nagle's algorithm              
-TCP_MAXSEG              536             Maximum segment size                   
-TCP_CORK                0               Control sending of partial frames      
-TCP_SYNCNT              6               Number of SYN retransmits              
-TCP_LINGER2             60              Lifetime of orphaned FIN-WAIT-2 state  
-TCP_DEFER_ACCEPT        0               Wake up listener only when data arrives
-TCP_WINDOW_CLAMP        0               Set maximum window size                
-TCP_INFO                10              Information about this socket          
-TCP_QUICKACK            1               Enable quick ACK                       
-TCP_CONGESTION          1768060259      Get/Set congestion control algorithm   
-TCP_REPAIR              0               TCP repair mode                        
-TCP_FASTOPEN            0               Enable TCP Fast Open                   
-TCP_TIMESTAMP           19100429        Enable TCP timestamps            
-```
+4. Change an option value:
+   ```bash
+   sudo sox set <pid> <fd> TCP_NODELAY 1
+   ```
 
-### Set socket option SO_KEEPALIVE to 1 for sshd process with PID=1062 and  tcp socket with FD=3
-```
-❯ sudo ./sox set 1062 3 SO_KEEPALIVE 1
-SOCKET_OPTION   VALUE   DESCRIPTION                    
-SO_KEEPALIVE    1       Enable or disable TCP keepalive
-```
-
-### Get value of socket option SO_KEEPALIVE for sshd process with PID=1062 and  tcp socket with FD=3
-```
-❯ sudo ./sox get 1062 3 SO_KEEPALIVE
-SOCKET_OPTION   VALUE   DESCRIPTION                    
-SO_KEEPALIVE    0       Enable or disable TCP keepalive
-```
+See the built in help (`sox --help`) for more commands and options.

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,13 +1,14 @@
 /*
 Copyright © 2024 Alexander Vysochin <avyssochin@gmail.com>
 */
+// Package cmd contains the CLI commands implemented using cobra.
 package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"strconv"
-	"log/slog"
 	"github.com/valexz/sox/pkg/sockopt"
+	"log/slog"
+	"strconv"
 )
 
 // getCmd represents the get command
@@ -17,15 +18,14 @@ var getCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		pid, err := strconv.Atoi(args[0])
 		if err != nil {
-			slog.Error("strconv.Atoi err:", err)
+			slog.Error("strconv.Atoi err", slog.Any("err", err))
 		}
 		fd, err := strconv.Atoi(args[1])
 		if err != nil {
-			slog.Error("strconv.Atoi err:", err)
+			slog.Error("strconv.Atoi err", slog.Any("err", err))
 		}
-	
+
 		option := args[2]
-	
 
 		sockopt.GetSocketOption(pid, fd, option)
 	},

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,6 +1,7 @@
 /*
 Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 */
+// Package cmd contains the CLI commands implemented using cobra.
 package cmd
 
 import (
@@ -18,11 +19,11 @@ var listCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		pid, err := strconv.Atoi(args[0])
 		if err != nil {
-			slog.Error("strconv.Atoi err:", err)
+			slog.Error("strconv.Atoi err", slog.Any("err", err))
 		}
 		fd, err := strconv.Atoi(args[1])
 		if err != nil {
-			slog.Error("strconv.Atoi err:", err)
+			slog.Error("strconv.Atoi err", slog.Any("err", err))
 		}
 
 		sockopt.ListSocketOptions(pid, fd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,11 +1,12 @@
 /*
 Copyright © 2024 Alexander Vysochin <avyssochin@gmail.com>
 */
+// Package cmd contains the CLI commands implemented using cobra.
 package cmd
 
 import (
-	"os"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -1,6 +1,7 @@
 /*
 Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 */
+// Package cmd contains the CLI commands implemented using cobra.
 package cmd
 
 import (
@@ -18,18 +19,18 @@ var setCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		pid, err := strconv.Atoi(args[0])
 		if err != nil {
-			slog.Error("strconv.Atoi err:", err)
+			slog.Error("strconv.Atoi err", slog.Any("err", err))
 		}
 		fd, err := strconv.Atoi(args[1])
 		if err != nil {
-			slog.Error("strconv.Atoi err:", err)
+			slog.Error("strconv.Atoi err", slog.Any("err", err))
 		}
 
 		option := args[2]
 
 		val, err := strconv.Atoi(args[3])
 		if err != nil {
-			slog.Error("strconv.Atoi err:", err)
+			slog.Error("strconv.Atoi err", slog.Any("err", err))
 		}
 
 		sockopt.SetSocketOption(pid, fd, option, val)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 /*
 Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 */
+// Sox is a simple CLI utility for inspecting and modifying TCP socket options.
 package main
 
 import (
@@ -8,6 +9,7 @@ import (
 )
 
 func main() {
+	// Execute runs the root command and subcommands provided by the cmd package.
 	cmd.Execute()
 }
 

--- a/pkg/sockopt/getsocketfd.go
+++ b/pkg/sockopt/getsocketfd.go
@@ -1,3 +1,4 @@
+// Package sockopt provides helpers for reading and modifying socket options.
 package sockopt
 
 import (
@@ -6,10 +7,14 @@ import (
 )
 
 var (
-	ErrUnableToGetPidFd    = errors.New("unable to get fd of pid")
+	// ErrUnableToGetPidFd is returned when pidfd.Open fails.
+	ErrUnableToGetPidFd = errors.New("unable to get fd of pid")
+	// ErrUnableToGetSocketFd is returned when the file descriptor cannot be obtained.
 	ErrUnableToGetSocketFd = errors.New("unable to get fd of pid")
 )
 
+// GetSocketFd returns a duplicate of file descriptor fd from the given process.
+// It utilises the pidfd mechanism and thus requires Linux 5.6+.
 func GetSocketFd(pid, fd int) (int, error) {
 	pidFD, err := pidfd.Open(pid, 0)
 	if err != nil {

--- a/pkg/sockopt/option.go
+++ b/pkg/sockopt/option.go
@@ -1,3 +1,4 @@
+// Package sockopt contains low level wrappers around various TCP socket options.
 package sockopt
 
 import (
@@ -5,6 +6,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// SocketOption describes a single socket option.
+// MinVal and MaxVal are used for basic range validation when setting values.
 type SocketOption struct {
 	Name        string
 	Option      int
@@ -14,6 +17,7 @@ type SocketOption struct {
 	Description string
 }
 
+// Set changes the value of the socket option for the given socket file descriptor.
 func (so SocketOption) Set(socketFD int, value int) error {
 	err := unix.SetsockoptInt(socketFD, so.Level, so.Option, value)
 	if err != nil {
@@ -24,6 +28,7 @@ func (so SocketOption) Set(socketFD int, value int) error {
 
 }
 
+// Get returns the current value of the socket option for the given socket file descriptor.
 func (so SocketOption) Get(socketFD int) (int, error) {
 	val, err := unix.GetsockoptInt(socketFD, so.Level, so.Option)
 	if err != nil {
@@ -33,10 +38,9 @@ func (so SocketOption) Get(socketFD int) (int, error) {
 	return val, err
 }
 
-// OptionsList Provides stable order for output of list command
+// OptionsList provides a stable order for the list command output.
 var OptionsList = []string{
 	"SO_KEEPALIVE",
-	"TCP_KEEPALIVE",
 	"TCP_KEEPIDLE",
 	"TCP_KEEPINTVL",
 	"TCP_KEEPCNT",
@@ -54,10 +58,12 @@ var OptionsList = []string{
 	"TCP_REPAIR",
 	"TCP_REPAIR_QUEUE",
 	"TCP_QUEUE_SEQ",
+	"TCP_REPAIR_OPTIONS",
 	"TCP_FASTOPEN",
 	"TCP_TIMESTAMP",
 }
 
+// OptionsMap maps the option name to its description and numeric identifiers.
 var OptionsMap = map[string]SocketOption{
 	"SO_KEEPALIVE": {
 		Level:       unix.SOL_SOCKET,
@@ -90,6 +96,14 @@ var OptionsMap = map[string]SocketOption{
 		MinVal:      1,
 		MaxVal:      32767,
 		Description: "Number of keepalives before death",
+	},
+	"TCP_USER_TIMEOUT": {
+		Name:        "TCP_USER_TIMEOUT",
+		Option:      unix.TCP_USER_TIMEOUT,
+		Level:       unix.IPPROTO_TCP,
+		MinVal:      1,
+		MaxVal:      0xFFFFFFFF,
+		Description: "Time to wait for peer response",
 	},
 	"TCP_NODELAY": {
 		Name:        "TCP_NODELAY",

--- a/pkg/sockopt/option_test.go
+++ b/pkg/sockopt/option_test.go
@@ -1,0 +1,87 @@
+package sockopt
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// helper to obtain fd from net.Conn
+func fdFromConn(c net.Conn) (int, error) {
+	sc, ok := c.(syscall.Conn)
+	if !ok {
+		return 0, os.ErrInvalid
+	}
+	raw, err := sc.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+	var fd int
+	err = raw.Control(func(f uintptr) {
+		fd = int(f)
+	})
+	return fd, err
+}
+
+func TestOptionsListInMap(t *testing.T) {
+	for _, name := range OptionsList {
+		if _, ok := OptionsMap[name]; !ok {
+			t.Errorf("option %s missing in OptionsMap", name)
+		}
+	}
+}
+
+func TestSetGetOption(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	ready := make(chan struct{})
+	go func() {
+		close(ready)
+		c, err := l.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		select {}
+	}()
+
+	<-ready
+	c, err := net.Dial("tcp", l.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	fd, err := fdFromConn(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// duplicate fd via pidfd
+	newfd, err := GetSocketFd(os.Getpid(), fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(newfd)
+
+	opt := OptionsMap["TCP_NODELAY"]
+
+	if err := opt.Set(newfd, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	val, err := opt.Get(newfd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != 1 {
+		t.Fatalf("expected 1 got %d", val)
+	}
+}

--- a/pkg/sockopt/sockopt.go
+++ b/pkg/sockopt/sockopt.go
@@ -1,3 +1,5 @@
+// Package sockopt contains helper functions used by the CLI commands for
+// listing and updating socket options.
 package sockopt
 
 import (
@@ -9,6 +11,7 @@ import (
 	"os"
 )
 
+// GetSocketName returns the IPv4 address and port of a socket file descriptor.
 func GetSocketName(socketFd int) string {
 	sn, _ := unix.Getsockname(socketFd)
 	sai4 := sn.(*unix.SockaddrInet4)
@@ -17,6 +20,7 @@ func GetSocketName(socketFd int) string {
 	return socketName
 }
 
+// ListSocketOptions prints all supported options for the given pid/fd pair.
 func ListSocketOptions(pid, fd int) {
 
 	socketFd, err := GetSocketFd(pid, fd)
@@ -56,6 +60,7 @@ func ListSocketOptions(pid, fd int) {
 
 }
 
+// SetSocketOption changes the option value for the socket defined by pid/fd.
 func SetSocketOption(pid, fd int, option string, val int) {
 
 	socketFd, err := GetSocketFd(pid, fd)
@@ -94,7 +99,8 @@ func SetSocketOption(pid, fd int, option string, val int) {
 
 }
 
-
+// GetSocketOption prints a single socket option value for the socket defined
+// by pid/fd.
 func GetSocketOption(pid, fd int, option string) {
 
 	socketFd, err := GetSocketFd(pid, fd)


### PR DESCRIPTION
## Summary
- clean up README for public consumption
- add missing `TCP_USER_TIMEOUT` option and list `TCP_REPAIR_OPTIONS`
- document code throughout
- fix slog usage and formatting
- add tests for socket options

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840b6168d68832bb648622ef27e0fd6