### PR TITLE
clarify privileges for pidfd errors

### DIFF
--- a/pkg/sockopt/getsocketfd.go
+++ b/pkg/sockopt/getsocketfd.go
@@ -7,10 +7,13 @@ import (
 )
 
 var (
-	// ErrUnableToGetPidFd is returned when pidfd.Open fails.
-	ErrUnableToGetPidFd = errors.New("unable to get fd of pid")
-	// ErrUnableToGetSocketFd is returned when the file descriptor cannot be obtained.
-	ErrUnableToGetSocketFd = errors.New("unable to get fd of pid")
+	// ErrUnableToGetPidFd is returned when pidfd.Open fails.  The operation
+	// requires either root privileges or the CAP_SYS_PTRACE capability.
+	ErrUnableToGetPidFd = errors.New("unable to get pid fd; run as root or with CAP_SYS_PTRACE")
+	// ErrUnableToGetSocketFd is returned when the file descriptor cannot be
+	// duplicated.  The operation requires either root privileges or the
+	// CAP_SYS_PTRACE capability.
+	ErrUnableToGetSocketFd = errors.New("unable to get fd of pid; run as root or with CAP_SYS_PTRACE")
 )
 
 // GetSocketFd returns a duplicate of file descriptor fd from the given process.


### PR DESCRIPTION
## Summary
- clarify that root or CAP_SYS_PTRACE permissions are needed when opening pidfd

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840b91f0090832ba76b83f0813bf9cc