### PR TITLE
Validate socket options and correct TCP_TIMESTAMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ TCP_QUICKACK            1               Enable quick ACK
 TCP_CONGESTION          1768060259      Get/Set congestion control algorithm
 TCP_REPAIR              0               TCP repair mode
 TCP_FASTOPEN            0               Enable TCP Fast Open
-TCP_TIMESTAMP           19100429        Enable TCP timestamps
+TCP_TIMESTAMP           19100429        Initial TCP timestamp value
 ```
 
 ### 3. Set a socket option

--- a/pkg/sockopt/sockopt.go
+++ b/pkg/sockopt/sockopt.go
@@ -46,7 +46,11 @@ func ListSocketOptions(pid, fd int) {
 			continue
 		}
 
-		table.AddRow(so.Name, val, so.Description)
+		display := any(val)
+		if so.Unsigned {
+			display = fmt.Sprintf("%d", uint32(val))
+		}
+		table.AddRow(so.Name, display, so.Description)
 	}
 
 	fmt.Println(table)
@@ -93,7 +97,11 @@ func SetSocketOption(pid, fd int, option string, val int) {
 
 	}
 
-	table.AddRow(so.Name, val, so.Description)
+	display := any(val)
+	if so.Unsigned {
+		display = fmt.Sprintf("%d", uint32(val))
+	}
+	table.AddRow(so.Name, display, so.Description)
 
 	fmt.Println(table)
 
@@ -127,7 +135,11 @@ func GetSocketOption(pid, fd int, option string) {
 
 	}
 
-	table.AddRow(so.Name, val, so.Description)
+	display := any(val)
+	if so.Unsigned {
+		display = fmt.Sprintf("%d", uint32(val))
+	}
+	table.AddRow(so.Name, display, so.Description)
 
 	fmt.Println(table)
 


### PR DESCRIPTION
## Summary
- enforce range validation in `SocketOption.Set`
- fix ranges for `TCP_LINGER2` and `TCP_WINDOW_CLAMP`
- add a test for invalid option values
- treat `TCP_TIMESTAMP` as an unsigned value
- clarify README description

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840be853668832bbc0adc4afef46816